### PR TITLE
_setMapDiv adjustments

### DIFF
--- a/src/js/bootstrapmap.js
+++ b/src/js/bootstrapmap.js
@@ -227,7 +227,7 @@ define(["esri/map", "esri/dijit/Popup", "esri/arcgis/utils", "dojo/_base/declare
               "height": mh2 + "px",
               "width": "100%"
             });
-			this._w = w;
+            this._w = w;
             this._wd = wd;
             //console.log("Window:" + w + " Body:" + b + " Room: " + room + " MapInner:" + mh + " MapSpace:" + ms + " OldMapHeight:" + mh1 + " NewMapHeight:" + mh2);
           }


### PR DESCRIPTION
Fixes #38

The issue I noticed was when a page had more body content bellow the map. This caused the _setMapDiv calculation to get a negative or rapidly fluctuating value for mh2. The result was the map rapidly flashed from small to large and often became stuck at a small size. This calculation takes the min of the previous window size and body content, or just takes body content if old window is 0 (not initialized). This solved all of my flickering issues. 
