### PR TITLE
Allow manipulation of map div dimensions

### DIFF
--- a/src/js/bootstrapmap.js
+++ b/src/js/bootstrapmap.js
@@ -236,7 +236,7 @@ define(["esri/map", "esri/dijit/Popup", "esri/arcgis/utils", "dojo/_base/declare
             // Expand map height
             style.set(this._mapDivId, {
               "height": mh2 + "px",
-              "width": "100%"
+              "width": "auto"
             });
             // Force resize and reposition
             if (this._map && forceResize && this._visible) {


### PR DESCRIPTION
I have a situation where the map is buddied with a sidebar that slides in and out by setting the map div's _right_ property to the width of the sidebar. This causes the map to re-size and re-position. Currently, the map div's _inline_ width is explicitly set to 100% and causes the sidebar to always cover the map. (The width is also set to 100% in CSS but this can be overridden.)

I've changed this behavior to set the width to _auto_ to account for these situations.
