### PR TITLE
reposition map div after title's CSS transition is complete

### DIFF
--- a/demo/dojo/webmap.html
+++ b/demo/dojo/webmap.html
@@ -260,6 +260,11 @@
 
         on(dom.byId("btnWebmap"),"click", loadWebmap);
         
+        //listen for when the title pane has finished expanding to reposition the map div
+        on(dom.byId("accordion0"), "transitionend, webkitTransitionEnd", function(){
+          map.reposition();
+        });
+
         function loadWebmap(e) {
 
           // Get new webmap and extract map and map parts

--- a/demo/jquery/webmap.html
+++ b/demo/jquery/webmap.html
@@ -254,7 +254,12 @@
         loadWebmap();
 
         on(dom.byId("btnWebmap"),"click", loadWebmap);
-        
+
+        //listen for when the title pane has finished expanding to reposition the map div
+        $(".collapse").on('transitionend webkitTransitionEnd',function(e){
+          map.reposition();
+        });
+
         function loadWebmap(e) {
 
           // Get new webmap and extract map and map parts


### PR DESCRIPTION
added both jquery and dojo event listeners to reposition map after title's CSS transition is complete to make sure map clicks continue to be triggered in the correct location
