### PR TITLE
add version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "bootstrap-map-js",
+    "version": "0.0.2",
     "description": "A light-weight JS/CSS extension for building responsive web mapping apps with ArcGIS and Bootstrap 3.",
     "author": "Allan Laframboise <alaframboise@esri.com> ",
     "license": "Apache 2",


### PR DESCRIPTION
only two things are required for npm package.json, "name" and "version".  Its not possible with the current version of npm to pull in this package without the version property

![image](https://cloud.githubusercontent.com/assets/6529123/23528548/3a04423e-ff68-11e6-9fd1-be76bda738bf.png)
